### PR TITLE
List of computers on Employee Edit

### DIFF
--- a/workforce-management/Controllers/EmployeesController.cs
+++ b/workforce-management/Controllers/EmployeesController.cs
@@ -112,6 +112,7 @@ namespace workforceManagement.Controllers
 
             //List 1
             List<Computer> notDecommissioned = new List<Computer>();
+            //BEGIN LOOPING OVER EVERY COMPUTER TO FIND ONES THAT ARE IN CIRCULATION
             foreach(var x in compy)
             { 
                 if(x.DecommisionDate == null)
@@ -119,14 +120,24 @@ namespace workforceManagement.Controllers
                     notDecommissioned.Add(x);
                 }
             }
+            //END
+
+            //BEGIN LOOPING OVER COMPUTERS IN CIRCULATION TO FIND ONES THAT 
+            //EXIST ON THE COMPUTER TABLE AND COMPUTEREMP TABLE AND HAS AN END DATE
+            //AND COMPUTERS THAT DON'T EXIST ON THE COMPUTEREMP TABLE
             foreach (var y in notDecommissioned)
             {
                 if (_context.ComputerEmp.Any(ce => y.ComputerId == ce.ComputerId && ce.End != null))
                 {
                     Empvm.Comp.Add(y);
                 }
+                if (!_context.ComputerEmp.Any(ce => y.ComputerId == ce.ComputerId ))
+                {
+                    Empvm.Comp.Add(y);
+                }
 
             }
+            //END
 
             ViewData["DepartmentId"] = new SelectList(_context.Set<Department>(), "DepartmentId", "DepartmentId", employee.DepartmentId);
 

--- a/workforce-management/Models/Computer.cs
+++ b/workforce-management/Models/Computer.cs
@@ -17,6 +17,6 @@ namespace workforceManagement.Models
         public string Make { get; set; }
         [Required]
         public string Manufacturer { get; set; }
-        public ICollection<ComputerEmp> ComputerEmp;
+        public ICollection<ComputerEmp> ComputerEmp { get; set; }
     }
 }

--- a/workforce-management/Models/ViewModels/EmployeeEditViewModel.cs
+++ b/workforce-management/Models/ViewModels/EmployeeEditViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace workforceManagement.Models.ViewModels
+{
+    public class EmployeeEditViewModel
+    {
+        public List<Computer> Comp { get; set; }
+        public List<TrainingProgram>Train {get;set;}
+        public Employee Emp { get; set; }
+        public EmployeeEditViewModel()
+        {
+            Comp = new List<Computer>();
+            Train = new List<TrainingProgram>();
+        }
+    }
+}

--- a/workforce-management/Views/Employees/Edit.cshtml
+++ b/workforce-management/Views/Employees/Edit.cshtml
@@ -1,4 +1,4 @@
-@model workforceManagement.Models.Employee
+@model workforceManagement.Models.ViewModels.EmployeeEditViewModel
 
 @{
     ViewData["Title"] = "Edit";
@@ -11,35 +11,51 @@
         <h4>Employee</h4>
         <hr />
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-    <input type="hidden" asp-for="EmployeeId" />
+    <input type="hidden" asp-for="Emp.EmployeeId" />
         <div class="form-group">
-            <label asp-for="Firstname" class="col-md-2 control-label"></label>
+            <label asp-for="Emp.Firstname" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="Firstname" class="form-control" />
-                <span asp-validation-for="Firstname" class="text-danger"></span>
+                <input asp-for="Emp.Firstname" class="form-control" />
+                <span asp-validation-for="Emp.Firstname" class="text-danger"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="Lastname" class="col-md-2 control-label"></label>
+            <label asp-for="Emp.Lastname" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="Lastname" class="form-control" />
-                <span asp-validation-for="Lastname" class="text-danger"></span>
+                <input asp-for="Emp.Lastname" class="form-control" />
+                <span asp-validation-for="Emp.Lastname" class="text-danger"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="Startdate" class="col-md-2 control-label"></label>
+            <label asp-for="Emp.Startdate" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="Startdate" class="form-control" />
-                <span asp-validation-for="Startdate" class="text-danger"></span>
+                <input asp-for="Emp.Startdate" class="form-control" />
+                <span asp-validation-for="Emp.Startdate" class="text-danger"></span>
             </div>
         </div>
         <div class="form-group">
-            <label asp-for="DepartmentId" class="control-label col-md-2"></label>
+            <label asp-for="Emp.DepartmentId" class="control-label col-md-2"></label>
             <div class="col-md-10">
-                <select asp-for="DepartmentId" class="form-control" asp-items="ViewBag.DepartmentId"></select>
-                <span asp-validation-for="DepartmentId" class="text-danger"></span>
+                <select asp-for="Emp.DepartmentId" class="form-control" asp-items="ViewBag.DepartmentId"></select>
+                <span asp-validation-for="Emp.DepartmentId" class="text-danger"></span>
             </div>
         </div>
+  
+        @{ 
+            List<SelectListItem> compitems = new List<SelectListItem>();
+            foreach(var x in Model.Comp)
+            {
+                compitems.Add(new SelectListItem
+                {
+                    Text = x.Make,
+                    Value = x.ComputerId.ToString()
+
+                });
+            }
+        }
+        @Html.DropDownList(
+        "Computers", compitems, "Make a selection")
+    
         <div class="form-group">
             <div class="col-md-offset-2 col-md-10">
                 <input type="submit" value="Save" class="btn btn-default" />


### PR DESCRIPTION
Fixes for #4

Changes proposed in this pull request:
- Added the Logic for getting back available computers that can be added to an employee
- Put loop in the view model to iterate over the selected items


How to test:
- Run the program / go to employees
- go to edit an employee and there should only be one computer that comes back

NOTE: On this branch you still cannot save the new laptop that you've added yet.

@PushyDonkey/